### PR TITLE
Add circle shapes to color processing

### DIFF
--- a/src-ui/utilities/prep-symbol.ts
+++ b/src-ui/utilities/prep-symbol.ts
@@ -28,7 +28,7 @@ export default function prepSymbol({ encodedSvg, elementName }: IPrepSymbolPaylo
     ).map(item => {
         const nodeString = `<${item}>`;
 
-        if (!nodeString.includes('<path') && !nodeString.includes('<rect')) {
+        if (!nodeString.includes('<path') && !nodeString.includes('<rect') && !nodeString.includes('<circle')) {
             return nodeString;
         }
 


### PR DESCRIPTION
Hello!

I've been using this plugin to generate sprites in Figma, but I noticed that one of our icon colors wasn't getting replaced.

This icon uses a circle, and it's important that we use that instead of a path to avoid chunkiness on lower DPI screens.

What do you think, does adding circles make sense?